### PR TITLE
[BUGFIX] Use https url to get oEmbed data

### DIFF
--- a/Classes/Helpers/DailymotionHelper.php
+++ b/Classes/Helpers/DailymotionHelper.php
@@ -89,8 +89,8 @@ class DailymotionHelper extends \TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\Abs
      */
     protected function getOEmbedUrl($mediaId, $format = 'json')
     {
-        return sprintf('http://www.dailymotion.com/services/oembed?url=%s&format=%s',
-            urlencode(sprintf('http://dai.ly/%s', $mediaId)),
+        return sprintf('https://www.dailymotion.com/services/oembed?url=%s&format=%s',
+            urlencode(sprintf('https://dai.ly/%s', $mediaId)),
             rawurlencode($format)
         );
     }


### PR DESCRIPTION
http url does not work anymore, https must be used to get data through oembed.